### PR TITLE
Fix build warning in debug build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,39 @@ on:
   pull_request:
 
 jobs:
+  build_aarch64_softmmu_debug_linux:
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:focal
+    steps:
+      - name: Install build dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build build-essential
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build qemu
+        run: |
+          mkdir build
+          cd build
+          ../configure --enable-debug --target-list=aarch64-softmmu --disable-capstone --disable-slirp
+          make -j$(nproc)
+
+      - name: Install qemu
+        run: |
+          cd build
+          make DESTDIR=$GITHUB_WORKSPACE/bin/ install
+
+      - name: Publish binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: aarch64_softmmu_linux_debug
+          path: ${{ github.workspace }}/bin/
+
   build_aarch64_softmmu_linux:
     runs-on: ubuntu-20.04
     container:

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -13269,7 +13269,7 @@ static inline void assert_hflags_rebuild_correctly(CPUARMState *env)
     uint64_t env_flags_rebuilt = rebuild_hflags_internal(env);
 
     if (unlikely(env_flags_current != env_flags_rebuilt)) {
-        fprintf(stderr, "TCG hflags mismatch (current:0x%16lx rebuilt:0x%16lx)\n",
+        fprintf(stderr, "TCG hflags mismatch (current:0x" TARGET_FMT_plx " rebuilt:0x" TARGET_FMT_plx ")\n",
                 env_flags_current, env_flags_rebuilt);
         abort();
     }

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -13269,7 +13269,7 @@ static inline void assert_hflags_rebuild_correctly(CPUARMState *env)
     uint64_t env_flags_rebuilt = rebuild_hflags_internal(env);
 
     if (unlikely(env_flags_current != env_flags_rebuilt)) {
-        fprintf(stderr, "TCG hflags mismatch (current:0x%16llx rebuilt:0x%16llx)\n",
+        fprintf(stderr, "TCG hflags mismatch (current:0x%16lx rebuilt:0x%16lx)\n",
                 env_flags_current, env_flags_rebuilt);
         abort();
     }


### PR DESCRIPTION
Building with `--enable-debug` would fail like this:

```
FAILED: libqemu-aarch64-softmmu.fa.p/target_arm_helper.c.o 
cc -Ilibqemu-aarch64-softmmu.fa.p -I. -I.. -Itarget/arm -I../target/arm -Iqapi -Itrace -Iui -Iui/shader -I/usr/include/pixman-1 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -fdiagnostics-color=auto -pipe -Wall -Winvalid-pch -Werror -std=gnu99 -g -m64 -mcx16 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -fwrapv -Wold-style-declaration -Wold-style-definition -Wtype-limits -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wempty-body -Wnested-externs -Wendif-labels -Wexpansion-to-defined -Wno-missing-include-dirs -Wno-shift-negative-value -Wno-psabi -fstack-protector-strong -isystem /__w/qemu-t8030/qemu-t8030/linux-headers -isystem linux-headers -iquote /__w/qemu-t8030/qemu-t8030/tcg/i386 -iquote . -iquote /__w/qemu-t8030/qemu-t8030 -iquote /__w/qemu-t8030/qemu-t8030/accel/tcg -iquote /__w/qemu-t8030/qemu-t8030/include -iquote /__w/qemu-t8030/qemu-t8030/disas/libvixl -pthread -fPIC -isystem../linux-headers -isystemlinux-headers -DNEED_CPU_H '-DCONFIG_TARGET="aarch64-softmmu-config-target.h"' '-DCONFIG_DEVICES="aarch64-softmmu-config-devices.h"' -MD -MQ libqemu-aarch64-softmmu.fa.p/target_arm_helper.c.o -MF libqemu-aarch64-softmmu.fa.p/target_arm_helper.c.o.d -o libqemu-aarch64-softmmu.fa.p/target_arm_helper.c.o -c ../target/arm/helper.c
../target/arm/helper.c: In function 'assert_hflags_rebuild_correctly':
../target/arm/helper.c:13272:62: error: format '%llx' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
13272 |         fprintf(stderr, "TCG hflags mismatch (current:0x%16llx rebuilt:0x%16llx)\n",
      |                                                         ~~~~~^
      |                                                              |
      |                                                              long long unsigned int
      |                                                         %16lx
13273 |                 env_flags_current, env_flags_rebuilt);
      |                 ~~~~~~~~~~~~~~~~~                             
      |                 |
      |                 uint64_t {aka long unsigned int}
../target/arm/helper.c:13272:79: error: format '%llx' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
13272 |         fprintf(stderr, "TCG hflags mismatch (current:0x%16llx rebuilt:0x%16llx)\n",
      |                                                                          ~~~~~^
      |                                                                               |
      |                                                                               long long unsigned int
      |                                                                          %16lx
13273 |                 env_flags_current, env_flags_rebuilt);
      |                                    ~~~~~~~~~~~~~~~~~                           
      |                                    |
      |                                    uint64_t {aka long unsigned int}
cc1: all warnings being treated as errors
```

This PR fixes that build warning/failure and adds a build leg which build with the `-enable-debug` flag enabled.